### PR TITLE
Push state names into vue-router to navigate to named routes.

### DIFF
--- a/src/helpers/VueRouter.js
+++ b/src/helpers/VueRouter.js
@@ -8,7 +8,7 @@ export default function setup (router, object)
 {
     function updateRoute()
     {
-        router.push('/' + object.fsm.state);
+        router.push({name: object.fsm.state});
     }
 
     // update route when state updates


### PR DESCRIPTION
Updated VueRouter helper to navigate to named routes. Fixes #14