### PR TITLE
Fix for bug #23 - fire state:{to}:enter when {to} is a function

### DIFF
--- a/src/core/classes/Transition.js
+++ b/src/core/classes/Transition.js
@@ -168,7 +168,6 @@ export default
         let scope   = fsm.config.scope;
         let from    = fsm.state;
         let to      = fsm.transitions.getStateFor(from, action);
-        let vars    = {action, to, from};
 
         // handle "to" being a function
         if(isFunction(to))
@@ -181,6 +180,7 @@ export default
         }
 
         // transition
+        let vars    = {action, to, from};
         let queue       = [];
         let transition  = new Transition(fsm, action, from, to);
 


### PR DESCRIPTION
A programmatic transition did not fire the state:a:enter handler